### PR TITLE
Update HAL for MuseLuxe

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -168,7 +168,7 @@ board_upload.flash_size = 8MB
 ;https://docs.platformio.org/en/latest/boards/espressif32/esp-wrover-kit.html
 board = esp-wrover-kit
 build_flags = ${env.build_flags}
-              -DHAL=5
+              -DHAL=10
               -DBOARD_HAS_PSRAM
               -mfix-esp32-psram-cache-issue
               -DLOG_BUFFER_SIZE=10240


### PR DESCRIPTION
## Summary
- adjust platformio config for MuseLuxe to use HAL=10

## Testing
- `platformio run -e esp32-MuseLuxe` *(fails: Aborted by user)*

------
https://chatgpt.com/codex/tasks/task_e_68406dd8e964832982e2ee93d98fc13f