### PR TITLE
Add neopixel setup for Muse Luxe

### DIFF
--- a/src/settings-raspiaudio_luxe.h
+++ b/src/settings-raspiaudio_luxe.h
@@ -16,6 +16,8 @@
 
 
     #define NUM_INDICATOR_LEDS		1          	// number of Neopixel LEDs (formerly NUM_LEDS)
+    #define NEOPIXEL_PIN                22              // Pin for the RGB LED on Muse Luxe
+    #define NUMPIXELS                   1               // Muse Luxe has 1 RGB LED
 	//#define RFID_READER_TYPE_MFRC522_I2C  // use MFRC522 via I2C
 	#undef USEROTARY_ENABLE                // If rotary-encoder is used (don't forget to review WAKEUP_BUTTON if you disable this feature!)
     #undef IR_CONTROL_ENABLE


### PR DESCRIPTION
## Summary
- add NEOPIXEL_PIN and NUMPIXELS definitions for Muse Luxe board

## Testing
- `pio run -e esp32-MuseLuxe` *(fails: `pio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840715766b08329a6fc838020ed8657