### PR TITLE
Fix memory release in Wlan.cpp

### DIFF
--- a/src/Wlan.cpp
+++ b/src/Wlan.cpp
@@ -231,9 +231,9 @@ static void migrateFromVersion2() {
 			}
 		}
 
-		// clean up old nvs entries
-		delete settings;
-		gPrefsSettings.remove(nvsKey);
+                // clean up old nvs entries
+                delete[] settings;
+                gPrefsSettings.remove(nvsKey);
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix delete on arrays in network settings migration

